### PR TITLE
Add CSS style sheet with @font-face declaration

### DIFF
--- a/webfonts/raleway.css
+++ b/webfonts/raleway.css
@@ -11,7 +11,7 @@
 @font-face {
   font-family: 'Raleway';
   font-weight: 100; /* Thin */
-  src: url('raleway_thin-webfont.eot'),
+  src: url('raleway_thin-webfont.eot');
   src: url('raleway_thin-webfont.eot?#iefix') format('embedded-opentype'),
        url('raleway_thin-webfont.woff') format('woff'),
        url('raleway_thin-webfont.ttf')  format('truetype'),

--- a/webfonts/raleway.css
+++ b/webfonts/raleway.css
@@ -11,6 +11,7 @@
 @font-face {
   font-family: 'Raleway';
   font-weight: 100; /* Thin */
+  src: url('raleway_thin-webfont.eot'),
   src: url('raleway_thin-webfont.eot?#iefix') format('embedded-opentype'),
        url('raleway_thin-webfont.woff') format('woff'),
        url('raleway_thin-webfont.ttf')  format('truetype'),

--- a/webfonts/raleway.css
+++ b/webfonts/raleway.css
@@ -1,0 +1,18 @@
+/*
+  'Raleway'
+  https://www.theleagueofmoveabletype.com/raleway
+
+  Copyright (c) 2010, Matt McInerney <matt@pixelspread.com>,
+  with Reserved Font Name: "Raleway".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Raleway';
+  font-weight: 100; /* Thin */
+  src: url('raleway_thin-webfont.eot?#iefix') format('embedded-opentype'),
+       url('raleway_thin-webfont.woff') format('woff'),
+       url('raleway_thin-webfont.ttf')  format('truetype'),
+       url('raleway_thin-webfont.svg#webfontnF3kUzPR') format('svg');
+}


### PR DESCRIPTION
The format used for the @font-face declaration is the
"Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
